### PR TITLE
Implement a macro that improves the codable strategy for enums

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "67c5007099d9ffdd292f421f81f4efe5ee42963e",
-        "version" : "509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-07-09-a"
+        "branch" : "swift-5.9-DEVELOPMENT-SNAPSHOT-2023-07-10-a",
+        "revision" : "67c5007099d9ffdd292f421f81f4efe5ee42963e"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,10 +13,6 @@ let package = Package(
             name: "DependenciesMacros",
             targets: ["DependenciesMacros"]
         ),
-        .executable(
-            name: "DependenciesMacrosClient",
-            targets: ["DependenciesMacrosClient"]
-        ),
     ],
     dependencies: [
         // Depend on the latest Swift 5.9 prerelease of SwiftSyntax

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         // Depend on the latest Swift 5.9 prerelease of SwiftSyntax
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0-swift-5.9-DEVELOPMENT-SNAPSHOT-2023-04-25-b"),
+        .package(url: "https://github.com/apple/swift-syntax.git", revision: "swift-5.9-DEVELOPMENT-SNAPSHOT-2023-07-10-a"),
         .package(url: "https://github.com/pointfreeco/swift-dependencies.git", from: "0.5.1")
     ],
     targets: [

--- a/Sources/DependenciesMacros/DependenciesMacros.swift
+++ b/Sources/DependenciesMacros/DependenciesMacros.swift
@@ -1,11 +1,2 @@
-// The Swift Programming Language
-// https://docs.swift.org/swift-book
-
-/// A macro that produces both a value and a string containing the
-/// source code that generated the value. For example,
-///
-///     #stringify(x + y)
-///
-/// produces a tuple `(x + y, "x + y")`.
-@freestanding(expression)
-public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "DependenciesMacrosMacros", type: "StringifyMacro")
+@attached(member, names: named(encode), named(init), named(SubType), named(CodingKeys))
+public macro EnumCodable() = #externalMacro(module: "DependenciesMacrosMacros", type: "EnumCodableMacro")

--- a/Sources/DependenciesMacrosClient/main.swift
+++ b/Sources/DependenciesMacrosClient/main.swift
@@ -1,4 +1,11 @@
 import DependenciesMacros
+import Foundation
 
+@EnumCodable
+enum TestEnum: Codable {
+    case user(name: String, age: Int)
+    case admin(name: String, age: Int) 
+}
 
-
+let data = try JSONEncoder().encode(TestEnum.user(name: "test", age: 123))
+print(String(data: data, encoding: .utf8)!)

--- a/Sources/DependenciesMacrosMacros/DependenciesMacrosMacro.swift
+++ b/Sources/DependenciesMacrosMacros/DependenciesMacrosMacro.swift
@@ -249,18 +249,6 @@ extension DependenciesMacroDiagnostic: DiagnosticMessage {
     }
 }
 
-@main
-public struct DependenciesMacrosPlugin: CompilerPlugin {
-    public static let macros: [String: Macro.Type] = [
-        "AutoDependency": AutoDependency.self,
-        "EnumCodable": EnumCodableMacro.self,
-    ]
-
-    public let providingMacros = Array(Self.macros.values)
-
-    public init() {}
-}
-
 struct DumpSyntaxMacro: PeerMacro {
     static func expansion(of node: AttributeSyntax, providingPeersOf declaration: some DeclSyntaxProtocol, in context: some MacroExpansionContext) throws -> [DeclSyntax] {
         dump(declaration)

--- a/Sources/DependenciesMacrosMacros/DependenciesMacrosMacro.swift
+++ b/Sources/DependenciesMacrosMacros/DependenciesMacrosMacro.swift
@@ -252,7 +252,8 @@ extension DependenciesMacroDiagnostic: DiagnosticMessage {
 @main
 public struct DependenciesMacrosPlugin: CompilerPlugin {
     public static let macros: [String: Macro.Type] = [
-        "AutoDependency": AutoDependency.self
+        "AutoDependency": AutoDependency.self,
+        "EnumCodable": EnumCodableMacro.self,
     ]
 
     public let providingMacros = Array(Self.macros.values)

--- a/Sources/DependenciesMacrosMacros/EnumMacro.swift
+++ b/Sources/DependenciesMacrosMacros/EnumMacro.swift
@@ -1,0 +1,247 @@
+import SwiftCompilerPlugin
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+import SwiftDiagnostics
+import SwiftBasicFormat
+
+struct NotEnumDiagnosticMessage: DiagnosticMessage {
+    let message: String = "Macro can only be applied to Enums"
+    let diagnosticID: MessageID = .init(domain: "unbtbl-macros", id: "enum-codable")
+    let severity: DiagnosticSeverity = .error
+}
+
+struct UnsuportedTypeDiagnosticMessage: DiagnosticMessage, Error {
+    let message: String = "Associated value type is not supported"
+    let diagnosticID: MessageID = .init(domain: "unbtbl-macros", id: "enum-case-value-type")
+    let severity: DiagnosticSeverity = .error
+}
+
+struct MissingEnumCaseLabelDiagnosticMessage: DiagnosticMessage, Error {
+    let message: String = "Associated value type in Enum Case is missing a label"
+    let diagnosticID: MessageID = .init(domain: "unbtbl-macros", id: "enum-case-value-missing-label")
+    let severity: DiagnosticSeverity = .error
+}
+
+internal struct EnumCase {
+    struct AssociatedValue {
+        let firstName: TokenSyntax
+        let type: TokenSyntax
+    }
+
+    let identifier: TokenSyntax
+    let associatedValues: [AssociatedValue]?
+
+    var tupleExpression: TupleExprSyntax? {
+        guard let associatedValues = associatedValues else {
+            return nil
+        }
+
+        return TupleExprSyntax {
+            TupleExprElementListSyntax {
+                for associatedValue in associatedValues {
+                    TupleExprElementSyntax(expression: IdentifierExprSyntax(identifier: associatedValue.firstName))
+                }
+            }
+        }
+    }
+
+    var tupleParameters: TupleTypeElementListSyntax? {
+        guard let associatedValues = associatedValues else {
+            return nil
+        }
+
+        return TupleTypeElementListSyntax {
+            for associatedValue in associatedValues {
+                TupleTypeElementSyntax(
+                    name: associatedValue.firstName,
+                    type: SimpleTypeIdentifierSyntax(name: associatedValue.type)
+                )
+            }
+        }
+    }
+
+    init?(_ enumCase: EnumCaseDeclSyntax, in context: some MacroExpansionContext) {
+        guard
+            let caseElement = enumCase.elements.first?.as(EnumCaseElementSyntax.self)
+        else {
+            return nil
+        }
+
+        self.identifier = caseElement.identifier
+        self.associatedValues = try? caseElement.associatedValue?.parameterList.map { parameter in
+            guard let typeName = parameter.type.as(SimpleTypeIdentifierSyntax.self)?.name else {
+                let error = UnsuportedTypeDiagnosticMessage()
+                context.diagnose(Diagnostic(
+                    node: parameter._syntaxNode,
+                    message: error
+                ))
+                throw UnsuportedTypeDiagnosticMessage()
+            }
+
+            guard let firstName = parameter.firstName else {
+                let error = MissingEnumCaseLabelDiagnosticMessage()
+                context.diagnose(Diagnostic(
+                    node: parameter._syntaxNode,
+                    message: error
+                ))
+                throw error
+            }
+
+            return AssociatedValue(
+                firstName: firstName,
+                type: typeName
+            )
+        }
+    }
+}
+
+public struct EnumCodableMacro: MemberMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard declaration.is(EnumDeclSyntax.self) else {
+            context.diagnose(Diagnostic(
+                node: declaration._syntaxNode,
+                message: NotEnumDiagnosticMessage()
+            ))
+            return []
+        }
+
+        let enumCases: [EnumCase] = declaration.memberBlock.members.compactMap { member -> EnumCase? in
+            guard
+                let decl = member.as(MemberDeclListItemSyntax.self),
+                let enumCase = decl.decl.as(EnumCaseDeclSyntax.self)
+            else {
+                return nil
+            }
+
+            return EnumCase(enumCase, in: context)
+        }
+
+        var encodeCases = [SwitchCaseSyntax]()
+        var decodeCases = [SwitchCaseSyntax]()
+        var decode = ""
+        var codingKeys = Set<TokenSyntax>()
+        var subtypes = Set<TokenSyntax>()
+        codingKeys.insert("type")
+
+        for enumCase in enumCases {
+            subtypes.insert(enumCase.identifier)
+
+            var caseUnwrap = ""
+
+            if let associatedValues = enumCase.associatedValues {
+                var cases = [String]()
+                for associatedValue in associatedValues {
+                    codingKeys.insert(associatedValue.firstName)
+                    cases.append("let \(associatedValue.firstName)")
+                }
+
+                caseUnwrap.append("(")
+                caseUnwrap.append(cases.joined(separator: ", "))
+                caseUnwrap.append(")")
+            }
+
+            let encodeLabel = SwitchCaseLabelSyntax {
+                if let tupleExpression = enumCase.tupleExpression {
+                    CaseItemSyntax(pattern: ExpressionPatternSyntax(expression: FunctionCallExprSyntax(
+                        calledExpression: MemberAccessExprSyntax(name: enumCase.identifier),
+                        argumentList: tupleExpression.elementList
+                    )))
+                } else {
+                    CaseItemSyntax(pattern: ExpressionPatternSyntax(expression: MemberAccessExprSyntax(name: enumCase.identifier)))
+                }
+            }
+
+            encodeCases.append(SwitchCaseSyntax(label: .case(encodeLabel), statements: CodeBlockItemListSyntax {
+                "try container.encode(SubType.\(enumCase.identifier), forKey: .type)"
+
+                if let associatedValues = enumCase.associatedValues {
+                    for associatedValue in associatedValues {
+                        "try container.encode(\(associatedValue.firstName), forKey: .\(associatedValue.firstName))"
+                    }
+                }
+            }))
+
+            decode += """
+            case .\(IdentifierExprSyntax(identifier: enumCase.identifier)):
+            """
+
+            if let associatedValues = enumCase.associatedValues {
+                var caseWrap = ""
+                var cases = [String]()
+
+                for associatedValue in associatedValues {
+                    decode += """
+                    let \(associatedValue.firstName) = try container.decode(\(associatedValue.type).self, forKey: .\(associatedValue.firstName))
+                    """
+
+                    cases.append("\(associatedValue.firstName): \(associatedValue.firstName)")
+                }
+
+                caseWrap.append("(")
+                caseWrap.append(cases.joined(separator: ", "))
+                caseWrap.append(")")
+                decode += """
+                self = .\(enumCase.identifier)\(caseWrap)
+                """
+            } else {
+                decode += """
+                self = .\(enumCase.identifier)
+                """
+            }
+        }
+
+        let codingKeysCases = codingKeys.sorted(by: { $0.text > $1.text }).map { key in
+            return EnumCaseDeclSyntax(elements: EnumCaseElementListSyntax {
+                EnumCaseElementSyntax(identifier: key)
+            })
+        }
+
+        let codingKeysDecl = EnumDeclSyntax("""
+        private enum CodingKeys: String, CodingKey {
+            \(raw: codingKeysCases)
+        }
+        """ as DeclSyntax)!
+
+        let subtypeText = subtypes.sorted(by: { $0.text > $1.text }).map { subtype in
+            return "case \(subtype)"
+        }.joined(separator: "\n")
+
+        let subtypeDecl = EnumDeclSyntax("""
+        enum SubType: String, Codable {
+            \(raw: subtypeText)
+        }
+        """ as DeclSyntax)!
+
+        let encodeSwitch = SwitchExprSyntax(expression: IdentifierExprSyntax(identifier: "self"), cases: SwitchCaseListSyntax(encodeCases.map { .switchCase($0) }))
+        let encodeDecl = FunctionDeclSyntax("""
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            \(encodeSwitch)
+        }
+        """ as DeclSyntax)!
+
+        let decodeDecl = InitializerDeclSyntax("""
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let subtype = try container.decode(SubType.self, forKey: .type)
+
+            switch subtype {
+            \(raw: decode)
+            }
+        }
+        """ as DeclSyntax)!
+
+        return [
+            subtypeDecl.as(DeclSyntax.self),
+            codingKeysDecl.as(DeclSyntax.self),
+            encodeDecl.as(DeclSyntax.self),
+            decodeDecl.as(DeclSyntax.self),
+        ]
+    }
+}

--- a/Sources/DependenciesMacrosMacros/Plugin.swift
+++ b/Sources/DependenciesMacrosMacros/Plugin.swift
@@ -1,0 +1,14 @@
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+public struct DependenciesMacrosPlugin: CompilerPlugin {
+    public static let macros: [String: Macro.Type] = [
+        "AutoDependency": AutoDependency.self,
+        "EnumCodable": EnumCodableMacro.self,
+    ]
+
+    public let providingMacros = Array(Self.macros.values)
+
+    public init() {}
+}

--- a/Tests/DependenciesMacrosTests/EnumCodableMacroTests.swift
+++ b/Tests/DependenciesMacrosTests/EnumCodableMacroTests.swift
@@ -1,0 +1,49 @@
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+@testable import DependenciesMacrosMacros
+
+final class EnumCodableMacroTests: XCTestCase {
+    func testMacro() {
+        assertMacroExpansion(
+            """
+            @EnumCodable
+            enum Role {
+                case nobody
+                case user(user: User)
+                case admin(user: Admin)
+            }
+            """,
+            expandedSource: """
+            enum Role {
+                case nobody
+                case user(user: User)
+                case admin(user: Admin)
+                enum SubType: String, Codable {
+                    case admin
+                    case nobody
+                    case user
+                }
+                private enum CodingKeys: String, CodingKey {
+                    case type
+                    case user
+                }
+                public func encode(to encoder: Encoder) throws {
+                    var container = encoder.container(keyedBy: CodingKeys.self)
+                    switch self {
+                    case .nobody:
+                        try container.encode(SubType.nobody, forKey: .type)
+                    case .user(let user):
+                        try container.encode(SubType.user, forKey: .type)
+                        try container.encode(user, forKey: .user)
+                    case .admin(let user):
+                        try container.encode(SubType.admin, forKey: .type)
+                        try container.encode(user, forKey: .user)
+                    }
+                }
+            }
+            """,
+            macros: DependenciesMacrosPlugin.macros
+        )
+    }
+}

--- a/Tests/DependenciesMacrosTests/EnumCodableMacroTests.swift
+++ b/Tests/DependenciesMacrosTests/EnumCodableMacroTests.swift
@@ -20,13 +20,10 @@ final class EnumCodableMacroTests: XCTestCase {
                 case user(user: User)
                 case admin(user: Admin)
                 enum SubType: String, Codable {
-                    case admin
-                    case nobody
-                    case user
+                    case nobody, user, admin
                 }
                 private enum CodingKeys: String, CodingKey {
-                    case type
-                    case user
+                    case type, user
                 }
                 public func encode(to encoder: Encoder) throws {
                     var container = encoder.container(keyedBy: CodingKeys.self)
@@ -39,6 +36,20 @@ final class EnumCodableMacroTests: XCTestCase {
                     case .admin(let user):
                         try container.encode(SubType.admin, forKey: .type)
                         try container.encode(user, forKey: .user)
+                    }
+                }
+                public init(from decoder: Decoder) throws {
+                    let container = try decoder.container(keyedBy: CodingKeys.self)
+                    let subtype = try container.decode(SubType.self, forKey: .type)
+                    switch subtype {
+                    case .nobody:
+                        self = .nobody
+                    case .user:
+                        let user = try container.decode(User.self, forKey: .user)
+                        self = .user(user: user)
+                    case .admin:
+                        let user = try container.decode(Admin.self, forKey: .user)
+                        self = .admin(user: user)
                     }
                 }
             }


### PR DESCRIPTION
Example Swift:

```swift
@EnumCodable
public enum UserType {
    case anonymous
    case user(user: User)
    case moderator(user: User)
}
```

Example `.anonymous` JSON:

```json
{
    "type": "anonymous"
}
```

Example `.user` JSON:

```json
{
    "type": "user",
    "user": {
        "username": ""
    }
}
```